### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,4 +123,4 @@ The tests can then be run via pytest.
 
 License
 -------
-py-pacz is licensed under the MIT license.
+``py-mel-logging`` is licensed under the MIT license.


### PR DESCRIPTION
Cut-n-paste error, changed it to reference the correct repository name.